### PR TITLE
chore: (docs): update github pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+Issue: 
+
+<details open> 
+  <summary>
+    <b>Feature</b>
+  </summary>
+
+N/A
+</details>
+
+<details open> 
+  <summary>
+    <b>Bugfix</b>
+  </summary>
+
+- **Description**
+N/A
+
+- **Cause**
+N/A
+
+- **Solution**
+N/A
+</details>
+
+<details> 
+  <summary>
+    <b>Changelog</b>
+  </summary>
+N/A
+</details>
+
+<details open> 
+  <summary>
+    <b>Visual evidences :framed_picture:</b>
+  </summary>
+
+</details>
+
+<details open> 
+  <summary>
+    <b>Checklist</b>
+  </summary>
+
+  - [ ] Issue linked
+  - [ ] Build working correctly
+  - [ ] Tests created
+</details>
+
+<details> 
+  <summary>
+    <b>Additional info</b>
+  </summary>
+N/A
+</details>


### PR DESCRIPTION
Issue: https://github.com/Alecell/octopost/issues/26


<details open> 
  <summary>
    <b>Feature</b>
  </summary>

This docs update adds a pull request template to set a standard for all of the pull requests. The provided solution is based on github documentation [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).

</details>

<details> 
  <summary>
    <b>Bugfix</b>
  </summary>

- **Description**
N/A

- **Cause**
N/A

- **Solution**
N/A
</details>

<details> 
  <summary>
    <b>Changelog</b>
  </summary>

- Adds a file `pull_request_template` 

</details>

<details> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [x] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>
N/A
</details>
