### PR TITLE
docs: add a new template for issues on github

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,60 @@
+## [Issue Title]
+
+_label: [tag1, tag2] 
+<br>
+assignees: [assignee_username]_
+
+<details open> 
+  <summary>
+    <b>Description</b>
+  </summary>
+   [Describe the issue or feature requested]
+</details>
+
+<br>
+
+<details> 
+  <summary>
+    <b>Steps to Reproduce</b>
+  </summary>
+
+  [If applicable, provide detailed steps to reproduce the issue.]
+
+</details>
+
+<br>
+
+<details> 
+  <summary>
+    <b>Expected Behavior</b>
+  </summary>
+  [Describe what you expect to happen.]
+</details>
+
+<br>
+
+<details> 
+  <summary>
+    <b>Current Behavior</b>
+  </summary>
+  [Describe what is currently happening.]
+</details>
+
+<br>
+
+<details> 
+  <summary>
+    <b>Visual information</b>
+  </summary>
+  [If possible, add screenshots to illustrate the issue.]
+</details>
+
+<br>
+
+<details> 
+  <summary>
+    <b>Additional Information</b>
+  </summary>
+  [Provide any additional information, such as relevant versions, context, etc.]
+
+</details>


### PR DESCRIPTION

Issue:  #82 


- **Description**

Create a new `template issue` for open new issues on github.


</details>

<details open> 
  <summary>
    <b>Changelog</b>
  </summary>
  
- add a new `issue_template.md` on `.github` dir
</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>


![template](https://github.com/Alecell/octopost/assets/54037222/1924c39a-0714-43db-9a62-7a84596839c5)

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [x] Tests created
</details>

