### PR TITLE
Add stories for Switch Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "electron:build": "yarn build && tsc -p electron && electron-builder",
     "electron:dist": "yarn build && tsc -p electron && electron-builder --mac --dir",
     "prepare": "husky install",
-    "stylelint": "stylelint \"**/*.scss\""
+    "stylelint": "stylelint \"**/*.scss\"",
+    "ladle": "ladle serve"
   },
   "build": {
     "productName": "octopost",

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -1,0 +1,11 @@
+import { useState } from 'react';
+
+import { Story } from '@ladle/react';
+
+import Switch from './Switch';
+
+export const SwitchComponent: Story = () => {
+  const [checked, setChecked] = useState(false);
+
+  return <Switch checked={checked} setChecked={setChecked} />;
+};

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,4 +1,4 @@
-import scss from './Swith.module.scss';
+import scss from './Switch.module.scss';
 
 import { ISwitch } from './Switch.types';
 


### PR DESCRIPTION
Issue: N/A

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

We had to create stories for our components, and to make by example I created this pull request creating an example of a Switch component on Ladle.

</details>

<details open> 
  <summary>
    <b>Changelog</b>
  </summary>

- Created switch stories
- Added a command on package.json to initialize Ladle
- Fixed a typo on Switch Component

</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

| Switch Component |
|--------|
| ![switch](https://github.com/Alecell/octopost/assets/61947632/8a59d0e6-5b7d-4dc5-be68-22c3ab111e89) | 


</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [x] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>
N/A
</details>
