### PR TITLE
Add stylelint on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - run: yarn install && yarn build && yarn test --watchAll=false && yarn lint
+      - name: install and build
+      - run: yarn install && yarn build
+
+      - name: jest tests
+      - run: yarn test --watchAll=fals
+
+      - name: lint tests
+      - run: yarn lint
+
+      - name: stylelint tests
+      - run: yarn stylelint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,21 +15,24 @@ jobs:
         node-version: [18.x]
 
     steps:
-      - name: code checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - name: Code checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: install and build
-      - run: yarn install && yarn build
+      - name: Install and build
+        run: |
+          yarn install
+          yarn build
 
-      - name: jest tests
-      - run: yarn test --watchAll=fals
+      - name: Run Jest tests
+        run: yarn test --watchAll=false
 
-      - name: lint tests
-      - run: yarn lint
+      - name: Lint tests
+        run: yarn lint
 
-      - name: stylelint tests
-      - run: yarn stylelint
+      - name: Stylelint tests
+        run: yarn stylelint

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "electron:dev": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://127.0.0.1:3000 && tsc -p electron -w\" \"wait-on http://127.0.0.1:3000 && tsc -p electron && electron .\"",
     "electron:build": "yarn build && tsc -p electron && electron-builder",
     "electron:dist": "yarn build && tsc -p electron && electron-builder --mac --dir",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "stylelint": "stylelint \"**/*.scss\""
   },
   "build": {
     "productName": "octopost",

--- a/src/components/Switch/Switch.module.scss
+++ b/src/components/Switch/Switch.module.scss
@@ -1,33 +1,40 @@
 .input {
-  position: relative;
   width: 48px;
   height: 28px;
-  outline: none;
+
+  position: relative;
+
   background: #c3c3c3;
-  border-radius: 50px;
-  appearance: none;
-  outline: none;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  outline: none;
+  outline: none;
+  border-radius: 50px;
+
   cursor: pointer;
-  
-  &:checked[type="checkbox"] {
-    background: #1e1e1e;
-  }
-  
-  &:before {
-    content: '';
+  appearance: none;
+
+  &::before {
+    padding: 0.8rem;
+
     position: absolute;
-    left: 0;
     right: 50%;
-    transition: all 250ms;
+    left: 0;
+
     background: #fff;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-    scale: 1.1;
-    padding: 0.8rem;
     border-radius: 50%;
+
+    transition: all 250ms;
+
+    content: '';
+    scale: 1.1;
   }
-  
-  &:checked[type="checkbox"]:before {
+
+  &:checked[type='checkbox'] {
+    background: #1e1e1e;
+  }
+
+  &:checked[type='checkbox']::before {
     right: 0;
     left: 50%;
   }

--- a/src/components/TextCopy/TextCopy.module.scss
+++ b/src/components/TextCopy/TextCopy.module.scss
@@ -1,16 +1,18 @@
 .textCopy {
-  border: 0.1rem solid #2e7ce1;
-  padding: 0.8rem;
-  border-radius: 0.6rem;
-
-  margin-top: 2rem;
+  color: #333;
   font-size: 1.4rem;
   font-weight: normal;
+  white-space: pre-wrap;
+
+  margin-top: 2rem;
+  padding: 0.8rem;
+  border: 0.1rem solid #2e7ce1;
+
   background-color: #f5f5f5;
-  color: #333;
+  border-radius: 0.6rem;
+
   cursor: default;
   user-select: text;
-  white-space: pre-wrap;
 
   &:hover {
     background-color: #eaeaea;

--- a/src/components/ToggleSocialMedia/ToggleSocialMedia.module.scss
+++ b/src/components/ToggleSocialMedia/ToggleSocialMedia.module.scss
@@ -1,10 +1,11 @@
 .wrapper {
   display: flex;
+
   align-items: center;
   justify-content: space-between;
 }
 
 .socialMedia {
-  font-weight: 600;
   font-size: 1.6rem;
+  font-weight: 600;
 }

--- a/src/pages/home/home.module.scss
+++ b/src/pages/home/home.module.scss
@@ -1,57 +1,69 @@
 .home {
   display: grid;
+
   color: #f2f2f2;
 }
 
 .navBar {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
   width: 100vw;
   height: 5rem;
+
+  display: flex;
+  flex-direction: row;
+
+  align-items: center;
+  justify-content: center;
+
   background-color: rgb(117, 31, 245);
 }
 
 .logo {
-  border-radius: 50%;
   width: 3rem;
   height: 3rem;
+
   margin-left: 10rem;
+
+  border-radius: 50%;
 }
 
 .mainContainer {
   width: 100vw;
   height: 100vh;
-  justify-content: center;
+
   align-items: center;
-  border: 0.4rem solid rgb(21, 233, 169);
+  justify-content: center;
+
   padding: 0.4rem;
+  border: 0.4rem solid rgb(21, 233, 169);
 }
 
 .gridContainer {
+  width: 100%;
+  height: 100%;
+
   display: grid;
-  grid-template-columns: minmax(100px, 0.2fr) 1fr;
-  grid-template-rows: 1fr 2fr;
   grid-template-areas:
     'switches input'
     'switches tabs';
+  grid-template-rows: 1fr 2fr;
+  grid-template-columns: minmax(100px, 0.2fr) 1fr;
   gap: 10px;
-  height: 100%;
-  width: 100%;
 }
 
 .gridSwitches {
   grid-area: switches;
-  border: 0.4rem solid red;
+
+  border: 0.4rem solid #f00;
 }
 
 .gridInput {
   grid-area: input;
-  border: 0.4rem solid blue;
+
+  border: 0.4rem solid rgb(0, 30, 255);
 }
 
 .gridTabs {
   grid-area: tabs;
-  border: 0.4rem solid yellow;
+
+  border: 0.4rem solid #ff0;
 }


### PR DESCRIPTION
Issue:  https://github.com/Alecell/octopost/issues/88

<details open> 
  <summary>
    <b>Bugfix</b>
  </summary>

- **Description**
Our Stylelint needs to be checked on CI

- **Cause**
Missed configuration for stylelint on github action

- **Solution**
Added Stylelint command and used on Github Action.


</details>

<details open> 
  <summary>
    <b>Changelog</b>
  </summary>

- Created stylelint command
- Fixed CI indentation
- Added Stylelint command on CI
- Fix stylelint on components to previne errors

</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

| Stylelint on CI |
|--------|
| ![image](https://github.com/Alecell/octopost/assets/61947632/5bc6f97d-551f-4596-98e1-f51c50601ab8)| 




</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [x] Tests created
</details>

<details open> 
  <summary>
    <b>Additional info</b>
  </summary>

Stylelint config to work properly on vscode. (Settings JSON must be edited)
```
 "eslint.validate": [
    "javascript",
    "javascriptreact",
    "typescript",
    "typescriptreact"
  ],
  "stylelint.validate": [
    "css",
    "html",
    "javascript",
    "javascriptreact",
    "less",
    "markdown",
    "postcss",
    "sass",
    "scss",
    "source.css.styled",
    "source.markdown.math",
    "styled-css",
    "sugarss",
    "svelte",
    "typescript",
    "typescriptreact",
    "vue",
    "vue-html",
    "vue-postcss",
    "xml",
    "xsl"
  ],
``` 

 

</details>
