### PR TITLE
fix: add the required info to create a new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,6 +1,14 @@
+---
+name: Issue
+about: Create a new issue to help us improve Octopost
+title: ''
+labels: needs triage
+assignees: ''
+---
+
 ## [Issue Title]
 
-_label: [tag1, tag2] 
+_label: [tag1, tag2]
 <br>
 assignees: [assignee_username]_
 
@@ -18,7 +26,7 @@ assignees: [assignee_username]_
     <b>Steps to Reproduce</b>
   </summary>
 
-  [If applicable, provide detailed steps to reproduce the issue.]
+[If applicable, provide detailed steps to reproduce the issue.]
 
 </details>
 


### PR DESCRIPTION
Issue: N/A

<details open> 
  <summary>
    <b>Bugfix</b>
  </summary>

- **Description**
The issue template needs this initial info to work properly on GitHub

- **Cause**
missed configuration

- **Solution**
added configuration provided

</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

![image](https://github.com/Alecell/octopost/assets/61947632/fc5dbd5b-3d68-4842-95a0-1b97c8cd1f86)
![image](https://github.com/Alecell/octopost/assets/61947632/c47a363b-b2aa-470b-a41e-321b21a7147e)

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [x] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>
N/A
</details>
