### PR TITLE
docs: add storie for text area

### DIFF
--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -1,0 +1,9 @@
+import { Story } from '@ladle/react';
+
+import CustomTextArea from './TextArea';
+
+export const TextAreaStories: Story = () => (
+  <div>
+    <CustomTextArea onTextChange={() => {}} />
+  </div>
+);


### PR DESCRIPTION


Issue: docs #102 


- **Description**
create ladle storie for `text area` component

- **Cause**
renders was in App.tsx, causing conflicts

- **Solution**
use ladle to render the component for testing

</details>

<details> 
  <summary>
    <b>Changelog</b>
  </summary>

- add a new file `TextArea.stories.tsx`
</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

![testecomponente](https://github.com/Alecell/octopost/assets/54037222/f43c8dd5-3001-4b02-b1fb-e6db539f526f)

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [x] Tests created
</details>

