### PR TITLE
test: add test for textarea component #93

### DIFF
--- a/src/components/TextArea/TextArea.spec.tsx
+++ b/src/components/TextArea/TextArea.spec.tsx
@@ -1,25 +1,26 @@
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
 
 import CustomTextArea from './TextArea';
 
 describe('CustomTextArea', () => {
-  it('should render the component textarea', () => {
-    const mockOnChange = jest.fn();
+  const mockOnChange = jest.fn();
+  it('renders the component textarea', () => {
     render(<CustomTextArea onTextChange={mockOnChange} />);
 
     const inputElement = screen.getByPlaceholderText('Digite algo aqui...');
     expect(inputElement).toBeInTheDocument();
   });
 
-  it('should update input value when typing', () => {
-    const mockOnChange = jest.fn();
+  it('updates input value when typing', () => {
     render(<CustomTextArea onTextChange={mockOnChange} />);
 
     const inputElement = screen.getByPlaceholderText(
       'Digite algo aqui...'
     ) as HTMLInputElement;
     const testInputValue = 'Testing TextArea input';
-    fireEvent.change(inputElement, { target: { value: testInputValue } });
+    act(() => {
+      fireEvent.change(inputElement, { target: { value: testInputValue } });
+    });
 
     expect(inputElement.value).toBe(testInputValue);
     expect(mockOnChange).toHaveBeenCalledWith(testInputValue);

--- a/src/components/TextArea/TextArea.spec.tsx
+++ b/src/components/TextArea/TextArea.spec.tsx
@@ -1,0 +1,27 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+
+import CustomTextArea from './TextArea';
+
+describe('CustomTextArea', () => {
+  it('should render the component textarea', () => {
+    const mockOnChange = jest.fn();
+    render(<CustomTextArea onTextChange={mockOnChange} />);
+
+    const inputElement = screen.getByPlaceholderText('Digite algo aqui...');
+    expect(inputElement).toBeInTheDocument();
+  });
+
+  it('should update input value when typing', () => {
+    const mockOnChange = jest.fn();
+    render(<CustomTextArea onTextChange={mockOnChange} />);
+
+    const inputElement = screen.getByPlaceholderText(
+      'Digite algo aqui...'
+    ) as HTMLInputElement;
+    const testInputValue = 'Testing TextArea input';
+    fireEvent.change(inputElement, { target: { value: testInputValue } });
+
+    expect(inputElement.value).toBe(testInputValue);
+    expect(mockOnChange).toHaveBeenCalledWith(testInputValue);
+  });
+});


### PR DESCRIPTION
Issue: test #93 

- **Description**
add test using jest for TextArea component

</details>

<details open> 
  <summary>
    <b>Changelog</b>
  </summary>

- add `TextArea.spec.tsx` 
</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

![testfortextarea](https://github.com/Alecell/octopost/assets/54037222/22114cb2-826e-4ba9-9e89-94926178ba17)

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [x] Tests created
</details>


