### PR TITLE
docs: Add storie documentation to toggleSocialMediaComponent with controls

### DIFF
--- a/src/components/ToggleSocialMedia/ToggleSocialMedia.stories.tsx
+++ b/src/components/ToggleSocialMedia/ToggleSocialMedia.stories.tsx
@@ -1,0 +1,17 @@
+import type { Story } from '@ladle/react';
+
+import ToggleSocialMedia from './ToggleSocialMedia';
+
+export const ToggleSocialMediaComponent: Story<{
+  socialMedia: string;
+}> = ({ socialMedia }) => {
+  return (
+    <div style={{ maxWidth: '20rem' }}>
+      <ToggleSocialMedia socialMedia={socialMedia} />
+    </div>
+  );
+};
+
+ToggleSocialMediaComponent.args = {
+  socialMedia: 'Reddit',
+};


### PR DESCRIPTION
Issue:  docs #103

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

This issue create a new Storie with the controls to control our component props.
</details>

<details open> 
  <summary>
    <b>Changelog</b>
  </summary>

- Added storie with controls
</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

| Using controls |
|--------|
| ![toggleSocial](https://github.com/Alecell/octopost/assets/61947632/6a9f7d6f-5169-4a6a-b78f-4f400b2bd7a1) | 

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
</details>

