### PR TITLE
docs: add preview component to ladle documentation

### DIFF
--- a/src/components/Preview/Preview.stories.tsx
+++ b/src/components/Preview/Preview.stories.tsx
@@ -1,0 +1,13 @@
+import type { Story } from '@ladle/react';
+
+import Preview from './Preview';
+
+export const PreviewComponent: Story<{ previewText: string }> = ({
+  previewText,
+}) => {
+  return <Preview>{previewText}</Preview>;
+};
+
+PreviewComponent.args = {
+  previewText: 'preview',
+};


### PR DESCRIPTION
Issue: #100 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

This issue create a new Storie with the controls to control our component props.
</details>

<details open> 
  <summary>
    <b>Changelog</b>
  </summary>

- Added storie with controls
</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

| Using controls |
|--------|
|![2023-08-19-19-39-11](https://github.com/Alecell/octopost/assets/103784814/145869fe-d1f7-43c3-8374-369303b817ff)| 

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [ ] Tests created
</details>

