### PR TITLE
feat: create character limit stories

### DIFF
--- a/src/components/CharacterLimit/CharacterLimit.stories.tsx
+++ b/src/components/CharacterLimit/CharacterLimit.stories.tsx
@@ -1,0 +1,15 @@
+import type { Story } from '@ladle/react';
+
+import CharacterLimit from './CharacterLimit';
+
+export const CharacterLimitComponent: Story<{
+  maxLength: number;
+  value: string;
+}> = ({ maxLength, value }) => (
+  <CharacterLimit maxLength={maxLength} value={value} />
+);
+
+CharacterLimitComponent.args = {
+  maxLength: 20,
+  value: 'Default value',
+};


### PR DESCRIPTION
Closes #98 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Create a story for a component that was created before Ladle was implemented.

</details>

<details> 
  <summary>
    <b>Changelog</b>
  </summary>

- Create stories for character limit component

</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

| Component on ladle |
|--------|
| ![image](https://github.com/Alecell/octopost/assets/61947632/8f8ca083-db08-4f92-a856-d9a5f0329784) | 

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  </details>
