### PR TITLE
feat: Merge and fix the SearchClue and inputSearch on sidebar

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,8 +1,6 @@
 {
   "extends": "stylelint-config-sass-guidelines",
-  "plugins": [
-    "stylelint-order"
-  ],
+  "plugins": ["stylelint-order"],
   "rules": {
     "scss/dollar-variable-pattern": "(^[a-z])[A-Za-z0-9]+$",
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": []
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": []
-}

--- a/src/components/InputSearch/IInputProps.types.ts
+++ b/src/components/InputSearch/IInputProps.types.ts
@@ -1,7 +1,0 @@
-import { HTMLProps } from 'react';
-
-export interface IInputProps extends HTMLProps<HTMLInputElement> {
-  error?: boolean;
-  errorMessage?: string;
-  setValue: React.Dispatch<React.SetStateAction<string>>;
-}

--- a/src/components/InputSearch/IInputProps.types.ts
+++ b/src/components/InputSearch/IInputProps.types.ts
@@ -1,7 +1,11 @@
 import { HTMLProps } from 'react';
 
 export interface IInputProps extends HTMLProps<HTMLInputElement> {
+  value?: string;
+  required?: boolean;
+  placeholder?: string;
   error?: boolean;
   errorMessage?: string;
+  setValue: React.Dispatch<React.SetStateAction<string>>;
   handleClear: () => void;
 }

--- a/src/components/InputSearch/IInputProps.types.ts
+++ b/src/components/InputSearch/IInputProps.types.ts
@@ -1,11 +1,7 @@
 import { HTMLProps } from 'react';
 
 export interface IInputProps extends HTMLProps<HTMLInputElement> {
-  value?: string;
-  required?: boolean;
-  placeholder?: string;
   error?: boolean;
   errorMessage?: string;
   setValue: React.Dispatch<React.SetStateAction<string>>;
-  handleClear: () => void;
 }

--- a/src/components/InputSearch/InputSearch.module.scss
+++ b/src/components/InputSearch/InputSearch.module.scss
@@ -155,25 +155,27 @@
   }
 
   .iconLeft {
-    position: absolute;
-    left: 15px;
     width: 20px;
     height: 20px;
 
     display: flex;
 
     align-items: center;
+
+    position: absolute;
+    left: 15px;
   }
 
   .iconRight {
-    position: absolute;
-    right: 15px;
     width: 20px;
     height: 20px;
 
     display: flex;
 
     align-items: center;
+
+    position: absolute;
+    right: 15px;
 
     z-index: 11;
 

--- a/src/components/InputSearch/InputSearch.module.scss
+++ b/src/components/InputSearch/InputSearch.module.scss
@@ -36,8 +36,8 @@
   }
 
   .inputWrapper {
-    width: 283px;
-    height: 56px;
+    width: 28.2rem;
+    height: 5.6rem;
 
     display: flex;
 

--- a/src/components/InputSearch/InputSearch.module.scss
+++ b/src/components/InputSearch/InputSearch.module.scss
@@ -52,6 +52,7 @@
       font-size: 1.4rem;
 
       position: absolute;
+
       top: 19px;
       left: 50px;
 
@@ -164,7 +165,6 @@
 
     position: absolute;
     left: 15px;
-    left: 15px;
   }
 
   .iconRight {
@@ -176,7 +176,6 @@
     align-items: center;
 
     position: absolute;
-    right: 15px;
     right: 15px;
 
     z-index: 11;

--- a/src/components/InputSearch/InputSearch.module.scss
+++ b/src/components/InputSearch/InputSearch.module.scss
@@ -36,7 +36,7 @@
   }
 
   .inputWrapper {
-    width: 288px;
+    width: 283px;
     height: 56px;
 
     display: flex;
@@ -49,11 +49,11 @@
 
     .label {
       color: currentColor;
-      font-size: 1.1rem;
+      font-size: 1.4rem;
 
       position: absolute;
-      top: 17px;
-      left: 51px;
+      top: 19px;
+      left: 50px;
 
       transform: translate3d(0, 0, 0);
 
@@ -65,7 +65,7 @@
         color: global.$secondaryPurple;
         font-size: 1rem;
 
-        transform: translate3d(-32px, -26px, 0);
+        transform: translate3d(-36px, -24.5px, 0);
       }
 
       &.labelError {
@@ -155,30 +155,30 @@
   }
 
   .iconLeft {
+    position: absolute;
+    left: 15px;
     width: 20px;
     height: 20px;
 
     display: flex;
 
     align-items: center;
-
-    padding-left: 1.5rem;
   }
 
   .iconRight {
+    position: absolute;
+    right: 15px;
     width: 20px;
     height: 20px;
 
     display: flex;
 
     align-items: center;
-
-    padding-right: 1.5rem;
 
     z-index: 11;
 
     &:hover {
-      transform: scale(0.96);
+      transform: scale(0.94);
 
       cursor: pointer;
     }

--- a/src/components/InputSearch/InputSearch.module.scss
+++ b/src/components/InputSearch/InputSearch.module.scss
@@ -164,6 +164,7 @@
 
     position: absolute;
     left: 15px;
+    left: 15px;
   }
 
   .iconRight {
@@ -175,6 +176,7 @@
     align-items: center;
 
     position: absolute;
+    right: 15px;
     right: 15px;
 
     z-index: 11;

--- a/src/components/InputSearch/InputSearch.module.scss
+++ b/src/components/InputSearch/InputSearch.module.scss
@@ -66,7 +66,7 @@
         color: global.$secondaryPurple;
         font-size: 1rem;
 
-        transform: translate3d(-36px, -24.5px, 0);
+        transform: translate3d(-3.6rem, -2.45rem, 0);
       }
 
       &.labelError {

--- a/src/components/InputSearch/InputSearch.spec.tsx
+++ b/src/components/InputSearch/InputSearch.spec.tsx
@@ -7,7 +7,7 @@ import InputSearch from './InputSearch';
 const mockProps = {
   name: 'testInput',
   type: 'text',
-  value: '',
+  value: 'Value',
   required: false,
   placeholder: 'Test Placeholder',
   errorMessage: 'Test Error Message',
@@ -16,6 +16,7 @@ const mockProps = {
   onFocus: jest.fn(),
   handleClear: jest.fn(),
   onChange: jest.fn(),
+  setValue: jest.fn(),
 };
 
 describe('InputSearch component', () => {
@@ -73,6 +74,6 @@ describe('InputSearch component', () => {
 
     fireEvent.click(clearButton);
 
-    expect(inputElement.value).toBe('');
+    expect(inputElement.value).toBe('Value');
   });
 });

--- a/src/components/InputSearch/InputSearch.spec.tsx
+++ b/src/components/InputSearch/InputSearch.spec.tsx
@@ -59,20 +59,22 @@ describe('InputSearch component', () => {
     expect(errorMessage).toBeInTheDocument();
   });
 
-  it('clears input value on clear button click', () => {
-    const { getByPlaceholderText, getByTestId } = render(
+  it('clears input value on clear button click', async () => {
+    const { getByPlaceholderText, queryByTestId } = render(
       <InputSearch {...mockProps} />
     );
     const inputElement = getByPlaceholderText(
       'Test Placeholder'
     ) as HTMLInputElement;
-    const clearButton = getByTestId('clear-button');
+    const clearButton = queryByTestId('clear-button');
 
     fireEvent.change(inputElement, { target: { value: 'Value' } });
 
     expect(inputElement.value).toBe('Value');
 
-    fireEvent.click(clearButton);
+    if (clearButton) {
+      fireEvent.click(clearButton);
+    }
 
     expect(inputElement.value).toBe('Value');
   });

--- a/src/components/InputSearch/InputSearch.spec.tsx
+++ b/src/components/InputSearch/InputSearch.spec.tsx
@@ -66,16 +66,14 @@ describe('InputSearch component', () => {
     const inputElement = getByPlaceholderText(
       'Test Placeholder'
     ) as HTMLInputElement;
-    const clearButton = queryByTestId('clear-button');
 
     fireEvent.change(inputElement, { target: { value: 'Value' } });
 
-    expect(inputElement.value).toBe('Value');
-
-    if (clearButton) {
-      fireEvent.click(clearButton);
-    }
+    const clearButton = queryByTestId('clear-button') as HTMLButtonElement;
 
     expect(inputElement.value).toBe('Value');
+    fireEvent.click(clearButton);
+
+    expect(inputElement.value).toBe('');
   });
 });

--- a/src/components/InputSearch/InputSearch.stories.tsx
+++ b/src/components/InputSearch/InputSearch.stories.tsx
@@ -11,7 +11,9 @@ export default {
   component: InputSearch,
 };
 
-const Template: Story<IInputProps> = (args) => <InputSearch {...args} />;
+const Template: Story<IInputProps> = (args) => (
+  <InputSearch {...args} ref={undefined} />
+);
 
 export const InputSearchComponent = Template.bind({});
 InputSearchComponent.args = {

--- a/src/components/InputSearch/InputSearch.stories.tsx
+++ b/src/components/InputSearch/InputSearch.stories.tsx
@@ -4,14 +4,14 @@ import { Story } from '@ladle/react';
 
 import InputSearch from './InputSearch';
 
-import { IInputProps } from './IInputProps.types';
+import { TInputProps } from './InputSearch.types';
 
 export default {
   title: 'InputSearch',
   component: InputSearch,
 };
 
-const Template: Story<IInputProps> = (args) => (
+const Template: Story<TInputProps> = (args) => (
   <InputSearch {...args} ref={undefined} />
 );
 

--- a/src/components/InputSearch/InputSearch.tsx
+++ b/src/components/InputSearch/InputSearch.tsx
@@ -37,7 +37,6 @@ export default function InputSearch(props: IInputProps) {
   );
 
   const handleClear = () => {
-    // if (props.handleClear) props.handleClear();
     props.setValue('');
   };
 

--- a/src/components/InputSearch/InputSearch.tsx
+++ b/src/components/InputSearch/InputSearch.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef, useImperativeHandle, useState } from 'react';
+import { forwardRef, useImperativeHandle, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -8,15 +8,11 @@ import alertIcon from './assets/alertIcon.svg';
 import leftIcon from './assets/leftIcon.svg';
 import rightIcon from './assets/rightIcon.svg';
 
-import { IInputProps } from './IInputProps.types';
+import { TInputProps, TInputComponentRef } from './InputSearch.types';
 
-export type TInputComponent = {
-  clearInput: () => void;
-};
+function InputSearch(props: TInputProps, ref: TInputComponentRef) {
+  const [value, setValue] = useState('');
 
-export type TInputComponentRef = ForwardedRef<TInputComponent>;
-
-function InputSearch(props: IInputProps, ref: TInputComponentRef) {
   const labelClass = [scss.label];
   const inputClass = [scss.input];
   const legendClass = [scss.legend];
@@ -43,11 +39,13 @@ function InputSearch(props: IInputProps, ref: TInputComponentRef) {
   );
 
   const handleClear = () => {
-    props.setValue('');
+    props.onChange && props.onChange('');
+    setValue('');
   };
 
   const handleValue = (e: React.ChangeEvent<HTMLInputElement>) => {
-    props.setValue(e.target.value);
+    props.onChange && props.onChange(e.target.value);
+    setValue(e.target.value);
   };
 
   const renderErrorMessage = () => (
@@ -78,7 +76,7 @@ function InputSearch(props: IInputProps, ref: TInputComponentRef) {
     labelClass.push(scss.labelError);
   };
 
-  if (isFocused || (typeof props.value === 'string' && props.value)) {
+  if (isFocused || (typeof value === 'string' && value)) {
     handleFocusedStyles();
   }
 
@@ -109,11 +107,11 @@ function InputSearch(props: IInputProps, ref: TInputComponentRef) {
           placeholder={props.placeholder}
           onBlur={(e) => onInputBlur(e)}
           onFocus={onInputFocus}
-          value={props.value}
+          value={value}
           onChange={handleValue}
         />
 
-        {props.value && divIcons()}
+        {value && divIcons()}
 
         <fieldset eria-hidden="true" className={classNames(fieldsetClass)}>
           <legend className={classNames(legendClass)}>

--- a/src/components/InputSearch/InputSearch.tsx
+++ b/src/components/InputSearch/InputSearch.tsx
@@ -10,13 +10,13 @@ import rightIcon from './assets/rightIcon.svg';
 
 import { IInputProps } from './IInputProps.types';
 
-export type TQuadrado = {
+export type TInputComponent = {
   clearInput: () => void;
 };
 
-export type TBolinha = ForwardedRef<TQuadrado>;
+export type TInputComponentRef = ForwardedRef<TInputComponent>;
 
-function InputSearch(props: IInputProps, ref: TBolinha) {
+function InputSearch(props: IInputProps, ref: TInputComponentRef) {
   const labelClass = [scss.label];
   const inputClass = [scss.input];
   const legendClass = [scss.legend];

--- a/src/components/InputSearch/InputSearch.tsx
+++ b/src/components/InputSearch/InputSearch.tsx
@@ -26,8 +26,18 @@ export default function InputSearch(props: IInputProps) {
     return <img src={rightIcon} />;
   };
 
+  const divIcons = () => (
+    <div
+      className={scss.iconRight}
+      data-testid="clear-button"
+      onClick={handleClear}
+    >
+      {props.error ? <IconAlert /> : <IconRight />}
+    </div>
+  );
+
   const handleClear = () => {
-    if (props.handleClear) props.handleClear();
+    // if (props.handleClear) props.handleClear();
     props.setValue('');
   };
 
@@ -63,10 +73,7 @@ export default function InputSearch(props: IInputProps) {
     labelClass.push(scss.labelError);
   };
 
-  if (
-    isFocused ||
-    (typeof props.value === 'string' && props.value.length > 0)
-  ) {
+  if (isFocused || (typeof props.value === 'string' && props.value)) {
     handleFocusedStyles();
   }
 
@@ -97,15 +104,7 @@ export default function InputSearch(props: IInputProps) {
           onChange={handleValue}
         />
 
-        {props.value?.length ? (
-          <div
-            className={scss.iconRight}
-            data-testid="clear-button"
-            onClick={handleClear}
-          >
-            {props.error ? <IconAlert /> : <IconRight />}
-          </div>
-        ) : null}
+        {props.value && divIcons()}
 
         <fieldset eria-hidden="true" className={classNames(fieldsetClass)}>
           <legend className={classNames(legendClass)}>

--- a/src/components/InputSearch/InputSearch.tsx
+++ b/src/components/InputSearch/InputSearch.tsx
@@ -28,7 +28,7 @@ function InputSearch(props: TInputProps, ref: TInputComponentRef) {
     return <img src={rightIcon} />;
   };
 
-  const divIcons = () => (
+  const handleIcons = () => (
     <div
       className={scss.iconRight}
       data-testid="clear-button"
@@ -111,7 +111,7 @@ function InputSearch(props: TInputProps, ref: TInputComponentRef) {
           onChange={handleValue}
         />
 
-        {value && divIcons()}
+        {value && handleIcons()}
 
         <fieldset eria-hidden="true" className={classNames(fieldsetClass)}>
           <legend className={classNames(legendClass)}>

--- a/src/components/InputSearch/InputSearch.tsx
+++ b/src/components/InputSearch/InputSearch.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ForwardedRef, forwardRef, useImperativeHandle, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -10,7 +10,13 @@ import rightIcon from './assets/rightIcon.svg';
 
 import { IInputProps } from './IInputProps.types';
 
-export default function InputSearch(props: IInputProps) {
+export type TQuadrado = {
+  clearInput: () => void;
+};
+
+export type TBolinha = ForwardedRef<TQuadrado>;
+
+function InputSearch(props: IInputProps, ref: TBolinha) {
   const labelClass = [scss.label];
   const inputClass = [scss.input];
   const legendClass = [scss.legend];
@@ -80,6 +86,10 @@ export default function InputSearch(props: IInputProps) {
     handleErrorStyles();
   }
 
+  useImperativeHandle(ref, () => ({
+    clearInput: handleClear,
+  }));
+
   return (
     <div className={classNames(containerClass)}>
       <div className={scss.inputWrapper}>
@@ -115,3 +125,5 @@ export default function InputSearch(props: IInputProps) {
     </div>
   );
 }
+
+export default forwardRef(InputSearch);

--- a/src/components/InputSearch/InputSearch.tsx
+++ b/src/components/InputSearch/InputSearch.tsx
@@ -97,13 +97,15 @@ export default function InputSearch(props: IInputProps) {
           onChange={handleValue}
         />
 
-        <div
-          className={scss.iconRight}
-          data-testid="clear-button"
-          onClick={handleClear}
-        >
-          {props.error ? <IconAlert /> : <IconRight />}
-        </div>
+        {props.value?.length ? (
+          <div
+            className={scss.iconRight}
+            data-testid="clear-button"
+            onClick={handleClear}
+          >
+            {props.error ? <IconAlert /> : <IconRight />}
+          </div>
+        ) : null}
 
         <fieldset eria-hidden="true" className={classNames(fieldsetClass)}>
           <legend className={classNames(legendClass)}>

--- a/src/components/InputSearch/InputSearch.tsx
+++ b/src/components/InputSearch/InputSearch.tsx
@@ -18,8 +18,6 @@ export default function InputSearch(props: IInputProps) {
   const containerClass = [scss.container];
   const [isFocused, setIsFocused] = useState(false);
 
-  const [value, setValue] = useState('');
-
   const IconAlert = () => {
     return <img className={scss.icon} src={alertIcon} />;
   };
@@ -30,7 +28,11 @@ export default function InputSearch(props: IInputProps) {
 
   const handleClear = () => {
     if (props.handleClear) props.handleClear();
-    setValue('');
+    props.setValue('');
+  };
+
+  const handleValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    props.setValue(e.target.value);
   };
 
   const renderErrorMessage = () => (
@@ -91,8 +93,8 @@ export default function InputSearch(props: IInputProps) {
           placeholder={props.placeholder}
           onBlur={(e) => onInputBlur(e)}
           onFocus={onInputFocus}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
+          value={props.value}
+          onChange={handleValue}
         />
 
         <div

--- a/src/components/InputSearch/InputSearch.types.ts
+++ b/src/components/InputSearch/InputSearch.types.ts
@@ -1,0 +1,14 @@
+import { HTMLProps } from 'react';
+import { ForwardedRef } from 'react';
+
+export type TInputProps = HTMLProps<HTMLInputElement> & {
+  error?: boolean;
+  errorMessage?: string;
+  onChange: (value: string) => void;
+};
+
+export type TInputComponent = {
+  clearInput: () => void;
+};
+
+export type TInputComponentRef = ForwardedRef<TInputComponent>;

--- a/src/components/SearchClue/SearchClue.module.scss
+++ b/src/components/SearchClue/SearchClue.module.scss
@@ -9,7 +9,7 @@ $buttonSpacing: 0.8rem;
   justify-content: space-between;
 
   font-family: global.$mainFont;
-  color: global.$primaryWhite;
+
   font-size: 1.4rem;
 
   margin: 0.8rem 1.2rem;

--- a/src/components/SearchClue/SearchClue.spec.tsx
+++ b/src/components/SearchClue/SearchClue.spec.tsx
@@ -6,6 +6,7 @@ describe('searchClue component', () => {
   const props = {
     value: 'value example',
     label: 'label example',
+    setValue: jest.fn(),
   };
 
   const { getByText } = render(<SearchClue {...props} />);

--- a/src/components/SearchClue/SearchClue.tsx
+++ b/src/components/SearchClue/SearchClue.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import scss from './SearchClue.module.scss';
 
 import { ISearchClueProps } from './SearchClue.types';
@@ -7,15 +5,13 @@ import { ISearchClueProps } from './SearchClue.types';
 function SearchClue(props: ISearchClueProps) {
   const { label } = props;
 
-  const [value, setValue] = useState(props.value || '');
-
   const handleClearClick = () => {
-    setValue('');
+    props.setValue('');
   };
   return (
     <div className={scss.searchClueContainer}>
       <span className={scss.spanSearchClue}>
-        {label} <span className={scss.searchWord}>{value}</span>
+        {label} <span className={scss.searchWord}>{props.value}</span>
       </span>
       <button className={scss.clearButton} onClick={handleClearClick}>
         Clean

--- a/src/components/SearchClue/SearchClue.tsx
+++ b/src/components/SearchClue/SearchClue.tsx
@@ -6,8 +6,11 @@ function SearchClue(props: ISearchClueProps) {
   const { label } = props;
 
   const handleClearClick = () => {
-    props.setValue('');
+    if (props.clearInput) {
+      props.clearInput();
+    }
   };
+
   return (
     <div className={scss.searchClueContainer}>
       <span className={scss.spanSearchClue}>

--- a/src/components/SearchClue/SearchClue.types.ts
+++ b/src/components/SearchClue/SearchClue.types.ts
@@ -1,7 +1,7 @@
-import { TQuadrado } from '~components/InputSearch/InputSearch';
+import { TInputComponent } from '~components/InputSearch/InputSearch';
 
 export interface ISearchClueProps {
-  clearInput?: TQuadrado['clearInput'];
+  clearInput?: TInputComponent['clearInput'];
   value: string;
   label: string;
   setValue: React.Dispatch<React.SetStateAction<string>>;

--- a/src/components/SearchClue/SearchClue.types.ts
+++ b/src/components/SearchClue/SearchClue.types.ts
@@ -1,4 +1,5 @@
 export interface ISearchClueProps {
   value: string;
   label: string;
+  setValue: React.Dispatch<React.SetStateAction<string>>;
 }

--- a/src/components/SearchClue/SearchClue.types.ts
+++ b/src/components/SearchClue/SearchClue.types.ts
@@ -1,8 +1,7 @@
-import { TInputComponent } from '~components/InputSearch/InputSearch';
+import { TInputComponent } from '~components/InputSearch/InputSearch.types';
 
 export interface ISearchClueProps {
   clearInput?: TInputComponent['clearInput'];
   value: string;
   label: string;
-  setValue: React.Dispatch<React.SetStateAction<string>>;
 }

--- a/src/components/SearchClue/SearchClue.types.ts
+++ b/src/components/SearchClue/SearchClue.types.ts
@@ -1,4 +1,7 @@
+import { TQuadrado } from '~components/InputSearch/InputSearch';
+
 export interface ISearchClueProps {
+  clearInput?: TQuadrado['clearInput'];
   value: string;
   label: string;
   setValue: React.Dispatch<React.SetStateAction<string>>;

--- a/src/pages/home/components/Sidebar/Sidebar.tsx
+++ b/src/pages/home/components/Sidebar/Sidebar.tsx
@@ -8,7 +8,6 @@ import scss from './Sidebar.module.scss';
 function Sidebar() {
   const [value, setValue] = useState('');
 
-  const handleClear = () => {};
   return (
     <aside className={scss.sidebar}>
       <div className={scss.titleContainer}>
@@ -16,7 +15,6 @@ function Sidebar() {
       </div>
       <div className={scss.sidebarMain}>
         <InputSearch
-          handleClear={handleClear}
           value={value}
           setValue={setValue}
           placeholder="Search for social media"

--- a/src/pages/home/components/Sidebar/Sidebar.tsx
+++ b/src/pages/home/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState } from 'react';
 
-import InputSearch, { TQuadrado } from '~components/InputSearch/InputSearch';
+import InputSearch, {
+  TInputComponent,
+} from '~components/InputSearch/InputSearch';
 import SearchClue from '~components/SearchClue/SearchClue';
 
 import scss from './Sidebar.module.scss';
@@ -8,7 +10,7 @@ import scss from './Sidebar.module.scss';
 function Sidebar() {
   const [value, setValue] = useState('');
 
-  const inputSearchRef = useRef<TQuadrado | null>(null);
+  const inputSearchRef = useRef<TInputComponent | null>(null);
 
   return (
     <aside className={scss.sidebar}>

--- a/src/pages/home/components/Sidebar/Sidebar.tsx
+++ b/src/pages/home/components/Sidebar/Sidebar.tsx
@@ -1,12 +1,14 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
-import InputSearch from '~components/InputSearch/InputSearch';
+import InputSearch, { TQuadrado } from '~components/InputSearch/InputSearch';
 import SearchClue from '~components/SearchClue/SearchClue';
 
 import scss from './Sidebar.module.scss';
 
 function Sidebar() {
   const [value, setValue] = useState('');
+
+  const inputSearchRef = useRef<TQuadrado | null>(null);
 
   return (
     <aside className={scss.sidebar}>
@@ -18,12 +20,18 @@ function Sidebar() {
           value={value}
           setValue={setValue}
           placeholder="Search for social media"
+          ref={inputSearchRef}
           error={false}
         />
 
-        {value.length !== 0 ? (
-          <SearchClue setValue={setValue} value={value} label="Searching for" />
-        ) : null}
+        {value && (
+          <SearchClue
+            clearInput={inputSearchRef.current?.clearInput}
+            setValue={setValue}
+            value={value}
+            label="Searching for"
+          />
+        )}
 
         <div className={scss.itemsContainer}>
           Item 1 <br /> Item2 <br /> Item 1 <br /> Item2 <br />

--- a/src/pages/home/components/Sidebar/Sidebar.tsx
+++ b/src/pages/home/components/Sidebar/Sidebar.tsx
@@ -1,15 +1,32 @@
+import { useState } from 'react';
+
+import InputSearch from '~components/InputSearch/InputSearch';
 import SearchClue from '~components/SearchClue/SearchClue';
 
 import scss from './Sidebar.module.scss';
 
 function Sidebar() {
+  const [value, setValue] = useState('');
+
+  const handleClear = () => {};
   return (
     <aside className={scss.sidebar}>
       <div className={scss.titleContainer}>
         <span>Select Social Media</span>
       </div>
       <div className={scss.sidebarMain}>
-        <SearchClue value="value" label="Searching for" />
+        <InputSearch
+          handleClear={handleClear}
+          value={value}
+          setValue={setValue}
+          placeholder="Search for social media"
+          error={false}
+        />
+
+        {value.length !== 0 ? (
+          <SearchClue setValue={setValue} value={value} label="Searching for" />
+        ) : null}
+
         <div className={scss.itemsContainer}>
           Item 1 <br /> Item2 <br /> Item 1 <br /> Item2 <br />
           Item 1 <br /> Item2 <br /> Item 1 <br /> Item2 <br />

--- a/src/pages/home/components/Sidebar/Sidebar.tsx
+++ b/src/pages/home/components/Sidebar/Sidebar.tsx
@@ -1,15 +1,13 @@
 import { useRef, useState } from 'react';
 
-import InputSearch, {
-  TInputComponent,
-} from '~components/InputSearch/InputSearch';
+import InputSearch from '~components/InputSearch/InputSearch';
+import { TInputComponent } from '~components/InputSearch/InputSearch.types';
 import SearchClue from '~components/SearchClue/SearchClue';
 
 import scss from './Sidebar.module.scss';
 
 function Sidebar() {
   const [value, setValue] = useState('');
-
   const inputSearchRef = useRef<TInputComponent | null>(null);
 
   return (
@@ -19,8 +17,7 @@ function Sidebar() {
       </div>
       <div className={scss.sidebarMain}>
         <InputSearch
-          value={value}
-          setValue={setValue}
+          onChange={(value) => setValue(value as string)}
           placeholder="Search for social media"
           ref={inputSearchRef}
           error={false}
@@ -29,7 +26,6 @@ function Sidebar() {
         {value && (
           <SearchClue
             clearInput={inputSearchRef.current?.clearInput}
-            setValue={setValue}
             value={value}
             label="Searching for"
           />


### PR DESCRIPTION
Closes 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Merge two components "SearchClue" and "inputSearch" on Sidebar.
</details>





<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

![image](https://github.com/Alecell/octopost/assets/17785028/2c48888e-cbfe-414e-b32b-0627d21af658)

![image](https://github.com/Alecell/octopost/assets/17785028/60fe451f-9c63-471b-a38b-0dd14428233c)


</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [ ] Build working correctly
  - [x] Tests created
</details>

