### PR TITLE
fix: mainComponent (make responsive)

### DIFF
--- a/src/components/MediaInputs/MediaInput.module.scss
+++ b/src/components/MediaInputs/MediaInput.module.scss
@@ -2,9 +2,9 @@
 
 .manyMediaContainer {
   display: grid;
-  grid-template-columns: repeat(10, minmax(10.4rem, auto));
+  grid-template-columns: repeat(5, minmax(10.4rem, auto));
 
-  gap: 1.4rem;
+  gap: 2.1px;
 
   align-items: center;
 


### PR DESCRIPTION
fix #183

Closes 


<details open> 
  <summary>
    <b>Bugfix</b>
  </summary>

- **Description**
The `mainComponent` was not responsive.

- **Cause**
What was causing this was a component that was together.
The `MediaInput` had a column for several images at once, creating an infinite invisible line, giving a side scroll on the page.

- **Solution**
The adjust of the component `MediaInput`

</details>


<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>

![print](https://github.com/Alecell/octopost/assets/54037222/d6f0d23b-bec9-4cee-a92e-05b2c8aab834)

  </summary>

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [x] Tests created
</details>


